### PR TITLE
Correct the dependency list

### DIFF
--- a/lib/open_graphy/version.rb
+++ b/lib/open_graphy/version.rb
@@ -1,3 +1,3 @@
 module OpenGraphy
-  VERSION = "1.0.0"
+  VERSION = "1.0.1"
 end

--- a/open_graphy.gemspec
+++ b/open_graphy.gemspec
@@ -17,10 +17,11 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "nokogiri", "~> 1.6"
+
   spec.add_development_dependency "bundler", "~> 1.7"
-  spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "nokogiri", "~> 1.6"
+  spec.add_development_dependency "rake", "~> 11.0"
   spec.add_development_dependency "rspec", "~> 3.1"
-  spec.add_development_dependency "vcr", '~> 2.9'
-  spec.add_development_dependency "webmock", "~> 1.20"
+  spec.add_development_dependency "vcr", '~> 3.0'
+  spec.add_development_dependency "webmock", "~> 2.1"
 end

--- a/spec/open_graphy_spec.rb
+++ b/spec/open_graphy_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
-describe OpenGraphy do
-  subject {
+RSpec.describe OpenGraphy do
+  subject(:open_graphy) {
     VCR.use_cassette('imdb/tt2084970') do
       OpenGraphy.fetch(url)
     end
@@ -12,6 +12,10 @@ describe OpenGraphy do
     it 'should return an object with the opengraph data' do
       expect(subject).to be_kind_of(OpenGraphy::MetaTags)
     end
+
+    it { expect(open_graphy.url).to eql('http://www.imdb.com/title/tt2084970/') }
+    it { expect(open_graphy.site_name).to eql('IMDb') }
+    it { expect(open_graphy.image).to eql('http://ia.media-imdb.com/images/M/MV5BNDkwNTEyMzkzNl5BMl5BanBnXkFtZTgwNTAwNzk3MjE@._V1_.jpg') }
   end
 
   describe 'custom metatags' do


### PR DESCRIPTION
Nokogiri was listed as a dev dependency but should be a runtime
dependecny.

This also bumps the version to 1.0.1 and adds to the open_graphy_spec
